### PR TITLE
added overlay for frequent and rapid dragging operations

### DIFF
--- a/Frontend/src/Components/Board/Board.tsx
+++ b/Frontend/src/Components/Board/Board.tsx
@@ -42,7 +42,18 @@ export const getElementsOnCanvas = () => {
   return elementsOnCanvas;  
 };
 
+const overlayForDrag = document.createElement("div");
+overlayForDrag.style.position = "fixed";
+overlayForDrag.style.top = "0";
+overlayForDrag.style.left = "0";
+overlayForDrag.style.width = "100vw";
+overlayForDrag.style.height = "100vh";
+overlayForDrag.style.cursor = "nwse-resize";
+overlayForDrag.style.zIndex = "9999";
+overlayForDrag.style.display = "none";
+overlayForDrag.className = "overlay-for-dragging";
 
+document.body.appendChild(overlayForDrag);
 
 const Board: React.FC = () => {
   console.log("inside board");

--- a/Frontend/src/Utils/Resize/cueBalls/topLeftCueBall/listeners.ts
+++ b/Frontend/src/Utils/Resize/cueBalls/topLeftCueBall/listeners.ts
@@ -10,6 +10,9 @@ export function attachListeners(topLeftCueBall: HTMLDivElement, canvasRef: React
     let dragStart = { x: 0, y: 0 };
     let dragEnd = { x: 0, y: 0 };
 
+    let overlayForDragging = document.querySelector(".overlay-for-dragging") as HTMLDivElement;
+    if(!overlayForDragging) return;
+
     const handleMouseMove = (e: MouseEvent) => {
         console.log("currently dragging");
         if (!isResizing || !canvasRef.current) return;
@@ -30,6 +33,7 @@ export function attachListeners(topLeftCueBall: HTMLDivElement, canvasRef: React
     const handleMouseUp = () => {
         console.log("stop dragging");
         isResizing = false;
+        overlayForDragging.style.display = "none";
         document.body.removeEventListener("mousemove", handleMouseMove);
         document.body.removeEventListener("mouseup", handleMouseUp);
         // Additional logic if needed on mouse up
@@ -40,7 +44,7 @@ export function attachListeners(topLeftCueBall: HTMLDivElement, canvasRef: React
         if(!canvasRef.current) return;
         isResizing = true;
         e.stopPropagation();
-       
+        overlayForDragging.style.display = "block";
         
         const rect = topLeftCueBall.getBoundingClientRect();
         const centerOfCueBall = {


### PR DESCRIPTION
A div element was created taking the entire width and height of the screen initially having the display property to none and the cursor style to "resize".

When the user starts dragging the element, the display property of the overlay is changed to "block" which effectively show the "Resize" cursor.

[DoddleDesk_7.webm](https://github.com/Lokendra-sinh/DoddleDesk/assets/138028282/4992b3d5-c265-43b6-b027-df9b6bd04580)



